### PR TITLE
Simplifies api

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,44 +21,32 @@ References:
 
 Require `supertest-session` and pass in the test application:
 
-    var Session = require('supertest-session')({
-      app: require('../../path/to/app')
-    });
+    var session = require('supertest-session');
+    var myApp = require('../../path/to/app');
 
-You can set environmental variables by including an `envs` object:
+    var testSession = null;
 
-    var Session = require('supertest-session')({
-      app: require('../../path/to/app'),
-      envs: { NODE_ENV: 'development' }
-    });
-
-Set up a session:
-
-    before(function () {
-      this.sess = new Session();
-    });
-
-    after(function () {
-      this.sess.destroy();
+    beforeEach(function () {
+      testSession = session(myApp);
     });
 
 And set some expectations:
 
     it('should fail accessing a restricted page', function (done) {
-      this.sess.get('/restricted')
+      testSession.get('/restricted')
         .expect(401)
         .end(done)
     });
 
     it('should sign in', function (done) {
-      this.sess.post('/signin')
+      testSession.post('/signin')
         .send({ username: 'foo', password: 'password' })
         .expect(200)
         .end(done);
     });
 
     it('should get a restricted page', function (done) {
-      this.sess.get('/restricted')
+      testSession.get('/restricted')
         .expect(200)
         .end(done)
     });
@@ -68,7 +56,7 @@ And set some expectations:
 The cookies attached to the session may be retrieved from `session.cookies` at any time, for instance to inspect the contents of the current session in an external store.
 
     it('should set session details correctly', function (done) {
-      var sessionCookie = _.find(sess.cookies, function (cookie) {
+      var sessionCookie = _.find(testSession.cookies, function (cookie) {
         return _.has(cookie, 'connect.sid');
       });
 
@@ -84,8 +72,7 @@ By default, supertest-session authenticates using session cookies. If your app
 uses a custom strategy to restore sessions, you can provide `before` and `after`
 hooks to adjust the request and inspect the response:
 
-    var Session = require('supertest-session')({
-      app: require('../../path/to/app'),
+    var testSession = session(myApp, {
       before: function (req) {
         req.set('authorization', 'Basic aGVsbG86d29ybGQK');
       }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var cookie = require('cookie'),
+var assign = require('object-assign'),
+    cookie = require('cookie'),
     methods = require('methods'),
     request = require('supertest'),
     util = require('util');
@@ -23,67 +24,98 @@ function serializeCookie (c) {
   }, []);
 }
 
-module.exports = function (config) {
+function Session (app, options) {
+
+  if (!app) {
+    throw new Error('Session requires an `app`');
+  }
+
+  this.app = app;
+  this.options = options || {};
+
+  if (this.options.helpers instanceof Object) {
+    assign(this, this.options.helpers);
+  }
+}
+
+Session.prototype._before = function (req) {
+  if (this.cookies) {
+    req.cookies = this.cookies.map(serializeCookie).join('; ');
+  }
+
+  if (this.options.before) {
+    this.options.before.call(this, req);
+  }
+};
+
+// Extract cookies once request is complete
+Session.prototype._after = function (req, res) {
+  if (this.options.after) {
+    this.options.after.call(this, req, res);
+  }
+
+  if (res.headers.hasOwnProperty('set-cookie')) {
+    this.cookies = res.headers['set-cookie'].map(cookie.parse);
+  }
+};
+
+Session.prototype.destroy = function () {
+  if (this.options.destroy) {
+    this.options.destroy.call(this);
+  }
+  this.cookies = null;
+};
+
+Session.prototype.request = function (meth, route) {
+  var req = request(this.app)[meth](route);
+  var sess = this;
+  var _end = req.end.bind(req);
+
+  this._before(req);
+
+  req.end = function (callback) {
+    return _end(function (err, res) {
+      if (err === null) sess._after(req, res);
+      return callback(err, res);
+    });
+  };
+
+  return req;
+};
+
+methods.forEach(function (m) {
+  Session.prototype[m] = function () {
+    var args = [].slice.call(arguments);
+    return this.request.apply(this, [m].concat(args));
+  };
+});
+
+Session.prototype.del = util.deprecate(Session.prototype.delete,
+  'supertest-session: Session.del is deprecated; please use Session.delete');
+
+function legacySession (config) {
 
   if (!config) config = {};
 
-  function Session () {
-    this.app = config.app;
+  // Bind session to `config`
+  function LegacySession () {
+    Session.call(this, config.app, config);
   }
 
-  Session.prototype._before = function (req) {
-    if (this.cookies) {
-      req.cookies = this.cookies.map(serializeCookie).join('; ');
-    }
-    if (config.before) config.before.call(this, req);
-  };
+  util.inherits(LegacySession, Session);
+  assign(LegacySession.prototype, {}, config.helpers);
 
-  // Extract cookies once request is complete
-  Session.prototype._after = function (req, res) {
-    if (config.after) config.after.call(this, req, res);
-    if (res.headers.hasOwnProperty('set-cookie')) {
-      this.cookies = res.headers['set-cookie'].map(cookie.parse);
-    }
-  };
+  return LegacySession;
+}
 
-  Session.prototype.destroy = function () {
-    if (config.destroy) config.destroy.call(this);
-    this.cookies = null;
-  };
+var deprecatedLegacySession = util.deprecate(legacySession,
+  'supertest-session: module configuration will be removed in next version.');
 
-  Session.prototype.request = function (meth, route) {
-    var req = request(this.app)[meth](route);
-    var sess = this;
-    var _end = req.end.bind(req);
-
-    this._before(req);
-
-    req.end = function (callback) {
-      return _end(function (err, res) {
-        if (err === null) sess._after(req, res);
-        return callback(err, res);
-      });
-    };
-
-    return req;
-  };
-
-  methods.forEach(function (m) {
-    Session.prototype[m] = function () {
-      var args = [].slice.call(arguments);
-      return this.request.apply(this, [m].concat(args));
-    };
-  });
-
-  Session.prototype.del = util.deprecate(Session.prototype.delete,
-    'Session.del is deprecated; please use Session.delete');
-
-  if (config.helpers instanceof Object) {
-    Object.keys(config.helpers).forEach(function (key) {
-      Session.prototype[key] = config.helpers[key];
-    });
+module.exports = function (app, options) {
+  if (!(app.listen instanceof Function)) {
+    return deprecatedLegacySession(app);
   }
 
-  return Session;
+  return new Session(app, options);
 };
 

--- a/index.js
+++ b/index.js
@@ -23,25 +23,12 @@ function serializeCookie (c) {
   }, []);
 }
 
-function assignEnvs (envs) {
-  Object.keys(envs).forEach(function(e) {
-    process.env[e] = envs[e];
-  });
-}
-
-var deprecatedAssignEnvs = util.deprecate(assignEnvs,
-  'supertest-session env configuration is deprecated and will be removed in next version.');
-
 module.exports = function (config) {
 
   if (!config) config = {};
 
   function Session () {
     this.app = config.app;
-
-    if (config.envs && (config.envs instanceof Object)) {
-      deprecatedAssignEnvs(config.envs);
-    }
   }
 
   Session.prototype._before = function (req) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "cookie": "^0.1.3",
     "methods": "^1.1.1",
+    "object-assign": "^4.0.1",
     "supertest": "^1.0.1"
   },
   "devDependencies": {

--- a/test/app.js
+++ b/test/app.js
@@ -29,12 +29,7 @@ function counter (req, res) {
 
   res.statusCode = 200;
 
-  if (req.url === '/env') {
-    res.end(JSON.stringify(process.env));
-  }
-  else {
-    res.end([req.method, req.session.type, req.session.count].join(','));
-  }
+  res.end([req.method, req.session.type, req.session.count].join(','));
 }
 
 app.use(counter);

--- a/test/compatibility_spec.js
+++ b/test/compatibility_spec.js
@@ -1,0 +1,84 @@
+var assert = require('assert'),
+    app = require('./app'),
+    session = require('../index');
+
+describe('legacy configuration', function () {
+
+  describe('supertest session', function () {
+
+    var sess = null;
+
+    var Session = session({
+      app: app
+    });
+
+    beforeEach(function (done) {
+      sess = new Session();
+      sess.request('get', '/')
+        .expect(200)
+        .expect('GET,,1')
+        .end(done);
+    });
+
+    it('should increment session counter', function (done) {
+      sess.request('get', '/')
+        .expect(200)
+        .expect('GET,,2')
+        .end(done);
+    });
+
+    it('should destroy session', function (done) {
+      sess.destroy();
+      sess.get('/')
+        .expect(200)
+        .expect('GET,,1')
+        .end(done);
+    });
+
+    describe('method sugar', function () {
+      var methods = {
+        'del'   : 'DELETE',
+        'get'   : 'GET',
+        'post'  : 'POST',
+        'put'   : 'PUT',
+        'patch' : 'PATCH'
+      };
+
+      Object.keys(methods).forEach(function (key) {
+        it('should support ' + key, function (done) {
+          sess[key]('/')
+            .expect(200)
+            .expect(methods[key] + ',,2')
+            .end(done);
+        });
+      });
+    });
+  });
+
+  describe('Session with a .before hook', function () {
+
+    var sess = null;
+
+    var Session = session({
+      app: app,
+      before: function (req) {
+        req.set('authorization', 'bearer TEST_SESSION_TOKEN');
+      }
+    });
+
+    beforeEach(function (done) {
+      sess = new Session();
+      sess.request('get', '/token')
+        .expect(200)
+        .expect('GET,token,1')
+        .end(done);
+    });
+
+    it('should increment session counter', function (done) {
+      sess.request('get', '/token')
+        .expect(200)
+        .expect('GET,token,2')
+        .end(done);
+    });
+  });
+});

--- a/test/main_spec.js
+++ b/test/main_spec.js
@@ -7,8 +7,7 @@ describe('supertest session', function () {
   var sess = null;
 
   var Session = session({
-    app: app,
-    envs: { NODE_ENV: 'development'}
+    app: app
   });
 
   beforeEach(function (done) {
@@ -24,16 +23,6 @@ describe('supertest session', function () {
       .expect(200)
       .expect('GET,,2')
       .end(done);
-  });
-
-  it('should set enviromental variables', function(done) {
-    sess.request('get', '/env')
-      .expect(200)
-      .end(function(err, res) {
-        assert.equal(err, undefined);
-        assert.equal(JSON.parse(res.text).NODE_ENV, 'development');
-        done();
-      });
   });
 
   it('should destroy session', function (done) {

--- a/test/main_spec.js
+++ b/test/main_spec.js
@@ -2,16 +2,12 @@ var assert = require('assert'),
     app = require('./app'),
     session = require('../index');
 
-describe('supertest session', function () {
+describe('supertest-session', function () {
 
   var sess = null;
 
-  var Session = session({
-    app: app
-  });
-
   beforeEach(function (done) {
-    sess = new Session();
+    sess = session(app);
     sess.request('get', '/')
       .expect(200)
       .expect('GET,,1')
@@ -57,15 +53,13 @@ describe('Session with a .before hook', function () {
 
   var sess = null;
 
-  var Session = session({
-    app: app,
-    before: function (req) {
-      req.set('authorization', 'bearer TEST_SESSION_TOKEN');
-    }
-  });
-
   beforeEach(function (done) {
-    sess = new Session();
+    sess = session(app, {
+      before: function (req) {
+        req.set('authorization', 'bearer TEST_SESSION_TOKEN');
+      }
+    });
+
     sess.request('get', '/token')
       .expect(200)
       .expect('GET,token,1')


### PR DESCRIPTION
This change brings the supertest-session API closer in-line with the
`supertest` API it wraps. Dependents adopting the new API should create
sessions using the exported factory function:

    var request = require('supertest-session');

    request(myApp, myOpts)
      .get('/hello')
      ...

The API remains back-compatible for the time being, though legacy usage
should be considered deprecated and will be removed in the future.