### PR TITLE
Fixes legacySession check for URL strings (#16)

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,9 @@ var deprecatedLegacySession = util.deprecate(legacySession,
   'supertest-session: module configuration will be removed in next version.');
 
 module.exports = function (app, options) {
-  if (typeof app != 'function') {
+
+  // Check for legacy interface and provide compatibility
+  if (app && app.app) {
     return deprecatedLegacySession(app);
   }
 

--- a/test/main_spec.js
+++ b/test/main_spec.js
@@ -47,6 +47,31 @@ describe('supertest-session', function () {
       });
     });
   });
+
+  describe('(#16) requesting URL of existing app', function () {
+
+    var serverUrl, test;
+
+    beforeEach(function () {
+      // use supertest to set up the app.js server, returning a `Test` instance
+      test = session(app).request('get', '');
+
+      // obtain the running server's URL
+      serverUrl = test.url;
+    });
+
+    afterEach(function (done) {
+      test.end(done);
+    });
+
+    it('behaves correctly', function (done) {
+      sess = session(serverUrl)
+        .get('/')
+        .expect(200)
+        .expect('GET,,1')
+        .end(done);
+    });
+  });
 });
 
 describe('Session with a .before hook', function () {


### PR DESCRIPTION
Basing compatibility code on the pre 1.1.10 `{ app }` option allows us to initialize requests by `String` url.