### PR TITLE
Upgrade to newer version of supertest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cookiejar": "^2.0.1",
     "methods": "^1.1.1",
     "object-assign": "^4.0.1",
-    "supertest": "^1.1.0"
+    "supertest": "^2.0.1"
   },
   "devDependencies": {
     "connect": "^3.2.0",


### PR DESCRIPTION
Upgrade to a newer version of supertest to fix double callback bug when using promises.