### PR TITLE
Add a way to configure the cookie jar CookieAccessInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ var testSession = session(myApp, {
 });
 ```
 
+### Cookie Jar Access Options
+
+By default supertest-session will derive the CookieAccessInfo config of the cookie jar from the
+agent configuration. There might be cases where you want to override this, e.g. if you're testing
+a service which is configured to run behind a proxy but which [sets secure
+cookies](https://expressjs.com/en/api.html#req.secure). To have supertest-session expose these
+secure cookies you can provide an override config to the internal call to
+[CookieAccessInfo](https://github.com/bmeck/node-cookiejar#cookieaccessinfodomainpathsecurescript):
+
+```js
+var cookieAccess = {
+  domain: 'example.com',
+  path: '/testpath',
+  secure: true,
+  script: true,
+};
+var testSession = session(myApp, { cookieAccess: cookieAccess });
+```
+
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -29,11 +29,12 @@ Object.defineProperty(Session.prototype, 'cookies', {
 
 Session.prototype.reset = function () {
 
-  var url, isSecure;
+  var url, cookieAccessOptions, domain, path, secure, script;
 
   // Unset supertest-session options before forwarding options to superagent.
   var agentOptions = assign({}, this.options, {
     before: undefined,
+    cookieAccess: undefined,
     destroy: undefined,
     helpers: undefined
   });
@@ -41,8 +42,12 @@ Session.prototype.reset = function () {
   this.agent = supertest.agent(this.app, agentOptions);
 
   url = parse(this.agent.get('').url);
-  isSecure = 'https:' == url.protocol;
-  this.cookieAccess = CookieAccess(url.hostname, url.pathname, isSecure);
+  cookieAccessOptions = this.options.cookieAccess || {};
+  domain = cookieAccessOptions.domain || url.hostname;
+  path = cookieAccessOptions.path || url.path;
+  secure = !!cookieAccessOptions.secure || 'https:' == url.protocol;
+  script = !!cookieAccessOptions.script || false;
+  this.cookieAccess = CookieAccess(domain, path, secure, script);
 };
 
 Session.prototype.destroy = function () {

--- a/test/main_spec.js
+++ b/test/main_spec.js
@@ -107,3 +107,32 @@ describe('Session with a .before hook', function () {
   });
 });
 
+describe('Session with a cookieConfig', function () {
+  it('should configure default cookieAccess', function (done) {
+    var sess = session(app);
+
+    assert.strictEqual(sess.cookieAccess.domain, '127.0.0.1');
+    assert.strictEqual(sess.cookieAccess.path, '/');
+    assert.strictEqual(sess.cookieAccess.secure, false);
+    assert.strictEqual(sess.cookieAccess.script, false);
+
+    done();
+  });
+
+  it('should allow to specify cookieAccess', function (done) {
+    var cookieAccess = {
+      domain: 'example.com',
+      path: '/testpath',
+      secure: true,
+      script: true,
+    };
+    var sess = session(app, { cookieAccess: cookieAccess });
+
+    assert.strictEqual(sess.cookieAccess.domain, cookieAccess.domain);
+    assert.strictEqual(sess.cookieAccess.path, cookieAccess.path);
+    assert.strictEqual(sess.cookieAccess.secure, cookieAccess.secure);
+    assert.strictEqual(sess.cookieAccess.script, cookieAccess.script);
+
+    done();
+  });
+});


### PR DESCRIPTION
By default supertest-session will derive the CookieAccessInfo config of
the cookie jar from the agent configuration. There might be cases where
you want to override this, e.g. if you're testing an service which is
configured to run behind a proxy but which [sets secure
cookies](https://expressjs.com/en/api.html#req.secure).

----

I'm a bit unsure whether this addition really fits the scope of this module.

An alternative workaround which works fine for me is to simply provide a small wrapper for supertest-session:

```js
import request from 'supertest-session';

export default function supertest(app) {
  const client = request(app, {
    before: (req) => {
      client.cookieAccess.secure = true;
      req.set('X-Forwarded-Proto', 'https');
    },
  });
  return client;
}
```

Let me know how you feel about it. I'm equally happy to change the pull request and maybe just add the workaround to the README if you think this is valuable but don't wan to change anything about the functionality of supertest-session.