### PR TITLE
Document how to make supertest use the CookieAccessInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ var cookieAccess = {
 var testSession = session(myApp, { cookieAccess: cookieAccess });
 ```
 
+By default the underlying `supertest` agent will still determine the CookieAccessInfo from the URL.
+If you want supertest-session to instead send cookies according to this `cookieAccess` config you
+can make use of the `before` hook:
+
+```js
+var cookieAccess = {
+  domain: 'example.com',
+  path: '/testpath',
+  secure: true,
+  script: true,
+};
+var testSession = session(myApp, {
+  cookieAccess: cookieAccess,
+  before: function (req) {
+    req.cookies = this.cookies.toValueString();
+  },
+});
+```
 
 ## License
 


### PR DESCRIPTION
Manually configuring the `cookieAccess` setting does not yet have any
effect on the behavior of the underlying supertest agent since the agent
has a CookieAccessInfo policy hardcoded, derived from the url:
https://github.com/visionmedia/superagent/blob/7bc01ecc30ca5fc4fcb493887334e650d901c5a3/lib/node/agent.js#L57

However there's an easy workaround to make use of the manually
configured `cookieAccess` config by setting the cookies in the before
hook which I have documented in this patch.