### PR TITLE
Allow app to be instance of https.Server for address parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var assign = require('object-assign'),
     supertest = require('supertest'),
     util = require('util'),
     http = require('http'),
+    https = require('https'),
     CookieAccess = require('cookiejar').CookieAccessInfo,
     parse = require('url').parse;
 
@@ -21,7 +22,7 @@ function Session (app, options) {
     app = http.createServer(app);
   }
 
-  if (app instanceof http.Server) {
+  if (app instanceof http.Server || app instanceof https.Server) {
     url = supertest.Test.prototype.serverAddress(app, '/');
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertest-session",
-  "version": "3.1.2",
+  "version": "3.1.2-https-support",
   "description": "Cookie-based session persistence for Supertest",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertest-session",
-  "version": "3.1.2-https-support",
+  "version": "3.1.2",
   "description": "Cookie-based session persistence for Supertest",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I ran into an issue attempting to test an app via `https.createServer(opts, app)`; this pull request will allow app to be an instance of https.Server (instead of only http.Server) when parsing the server URL.

When testing against HTTPS with a self-signed certificate a root CA will be needed, but this option can be provided to `supertest-session` via:

```
var app = express()

// ...setup express app... 

var httpsApp = require('https').createServer({
	key: fs.readFileSync('../path/to/host-key.pem'),
	cert: fs.readFileSync('../path/to/host-cert-with-chain-from-ca.crt'),
	rejectUnauthorized: true,
}, app);

var testHttpsSession = require('supertest-session')(httpsApp, {
	ca: fs.readFileSync('../path/to/ca-cert.crt')
});
```

As for adding tests, I didn't feel it was worth bringing fake certificate files into this repo for the sake of testing https, but have no problem adding them if they're required to complete the merge.

I have been using this fork locally in a number of projects (via a private npm repo) and it doesn't appear to have any negative effect, or change in functionality.

Lastly, I was unsure if a package.json change was required, but didn't want it to be confused with the existing version.

Let me know if there is anything I can do to help make this easier to merge.