### PR TITLE
fix: add missing dependencies cookiejar and methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -453,8 +453,7 @@
     "cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-      "dev": true
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "cookies": {
       "version": "0.7.3",
@@ -1132,8 +1131,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "supertest": ">= 3.1.0"
   },
   "dependencies": {
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "cookiejar": "^2.1.2",
+    "methods": "^1.1.2"
   },
   "devDependencies": {
     "connect": "^3.6.6",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`supertest-session` is using `methods` and `cookiejar` without declaring them as dependencies causing it to rely on something else in the dependency tree to declare it and that it's hoisted to an accesible location which is really fragile and prone to breaking. Under strict dependency systems like pnpm and Yarn PnP this does not work

Fixes https://github.com/rjz/supertest-session/issues/45

**How did you fix it?**

Added missing dependencies `cookiejar` and `methods`